### PR TITLE
fix for string-slice flags

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -194,11 +194,7 @@ func assignSlices(app *cobra.Command, slices map[string]reflect.Value) error {
 			return err
 		}
 		if s != nil {
-			// TODO: weird BUG?
-			if len(s) > 1 {
-				s = s[:len(s)/2]
-			}
-			v.Set(reflect.ValueOf(s))
+			v.Set(reflect.ValueOf(s[:]))
 		}
 	}
 	return nil


### PR DESCRIPTION
I chatted with @ibuildthecloud about this which corrects a hack for a half-remembered bug that was causing string slice flags to get truncated,