### PR TITLE
support for string array flags

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -117,8 +117,8 @@ func Command(obj Runnable, cmd cobra.Command) *cobra.Command {
 		case reflect.String:
 			flags.StringVarP((*string)(unsafe.Pointer(v.Addr().Pointer())), name, alias, defValue, usage)
 		case reflect.Slice:
-			switch fieldType.Tag.Get("slice") {
-			case "array":
+			switch fieldType.Tag.Get("split") {
+			case "false":
 				arrays[name] = v
 				flags.StringArrayP(name, alias, nil, usage)
 			default:

--- a/example/pkg/app/app.go
+++ b/example/pkg/app/app.go
@@ -18,6 +18,8 @@ func New() *cobra.Command {
 type App struct {
 	OptionOne string `usage:"Some usage description"`
 	OptionTwo string `name:"custom-name"`
+	SliceOne []string `name:"string-array" slice:"array"`
+	SliceTwo []string `name:"string-slice"`
 }
 
 func (a *App) Run(cmd *cobra.Command, args []string) error {

--- a/example/pkg/app/app.go
+++ b/example/pkg/app/app.go
@@ -18,7 +18,7 @@ func New() *cobra.Command {
 type App struct {
 	OptionOne string `usage:"Some usage description"`
 	OptionTwo string `name:"custom-name"`
-	SliceOne []string `name:"string-array" slice:"array"`
+	SliceOne []string `name:"string-array" split:"false"`
 	SliceTwo []string `name:"string-slice"`
 }
 


### PR DESCRIPTION
Fields that store values as a slice of strings and have the "slice" tag
with a value of "array" will be treated as **StringArray** instead of
**StringSlice**.

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>