### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  -
+    package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Adding a dependabot config to configure how dependabot will create PRs to update go modules.


Refers to https://github.com/rancher/fleet/issues/803